### PR TITLE
Decoder input mp3 info

### DIFF
--- a/examples/mp32wav.js
+++ b/examples/mp32wav.js
@@ -47,7 +47,8 @@ decoder.on('format', onFormat);
 input.pipe(decoder);
 
 function onFormat (format) {
-  console.error('MP3 format: %j', format);
+  console.error('MP3 info: %j', decoder.info());
+  console.error('output format: %j', format);
 
   // write the decoded MP3 data into a WAV file
   var writer = new wav.Writer(format);

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -153,3 +153,13 @@ Decoder.prototype._transform = function (chunk, encoding, done) {
     read();
   }
 };
+
+/**
+ * Calls `mpg123_info()` to get info about the input mp3 format.
+ */
+
+Decoder.prototype.info = function () {
+  var info = binding.mpg123_info(this.mh);
+  debug('info: %j', info);
+  return info;
+};

--- a/src/node_mpg123.cc
+++ b/src/node_mpg123.cc
@@ -139,6 +139,30 @@ Handle<Value> node_mpg123_getformat (const Arguments& args) {
   return scope.Close(rtn);
 }
 
+Handle<Value> node_mpg123_info (const Arguments& args) {
+  UNWRAP_MH;
+  mpg123_frameinfo info;
+  int ret;
+  Local<Value> rtn;
+  ret = mpg123_info(mh, &info);
+  if (ret == MPG123_OK) {
+    Local<Object> o = Object::New();
+    o->Set(String::NewSymbol("version"), Number::New(info.version));
+    o->Set(String::NewSymbol("layer"), Number::New(info.layer));
+    o->Set(String::NewSymbol("bitRate"), Number::New(info.bitrate));
+    o->Set(String::NewSymbol("sampleRate"), Number::New(info.rate));
+    o->Set(String::NewSymbol("mode"), Number::New(info.mode));
+    o->Set(String::NewSymbol("modeExtension"), Number::New(info.mode_ext));
+    o->Set(String::NewSymbol("frameSize"), Number::New(info.framesize));
+    o->Set(String::NewSymbol("emphasis"), Number::New(info.emphasis));
+    o->Set(String::NewSymbol("vbr"), Number::New(info.vbr));
+    o->Set(String::NewSymbol("averageBitRate"), Number::New(info.abr_rate));
+    rtn = o;
+  } else {
+    rtn = Integer::New(ret);
+  }
+  return scope.Close(rtn);
+}
 
 Handle<Value> node_mpg123_safe_buffer (const Arguments& args) {
   HandleScope scope;
@@ -502,6 +526,7 @@ void InitMPG123(Handle<Object> target) {
   NODE_SET_METHOD(target, "mpg123_current_decoder", node_mpg123_current_decoder);
   NODE_SET_METHOD(target, "mpg123_supported_decoders", node_mpg123_supported_decoders);
   NODE_SET_METHOD(target, "mpg123_getformat", node_mpg123_getformat);
+  NODE_SET_METHOD(target, "mpg123_info", node_mpg123_info);
   NODE_SET_METHOD(target, "mpg123_safe_buffer", node_mpg123_safe_buffer);
   NODE_SET_METHOD(target, "mpg123_outblock", node_mpg123_outblock);
   NODE_SET_METHOD(target, "mpg123_framepos", node_mpg123_framepos);


### PR DESCRIPTION
exposed mpg123_info to get information about the input mp3 format (bitrate, samplerate, etc.)

I just added a public `.info()` method, I wasn't sure but it might be useful to include that info when triggering the `format` event.

one use case I wrote this for is transcoding, I want to transcode from quality A to B, but I want to passthrough (omit the transcoding) if A === B.
