### PR TITLE
node 0.12 support

### DIFF
--- a/src/node_lame.cc
+++ b/src/node_lame.cc
@@ -260,7 +260,7 @@ NAN_METHOD(node_lame_get_id3v1_tag) {
   size_t buf_size = (size_t)Buffer::Length(outbuf);
 
   size_t b = lame_get_id3v1_tag(gfp, buf, buf_size);
-  NanReturnValue(NanNew<Integer>(b));
+  NanReturnValue(NanNew<Integer>(static_cast<uint32_t>(b)));
 }
 
 
@@ -277,7 +277,7 @@ NAN_METHOD(node_lame_get_id3v2_tag) {
   size_t buf_size = (size_t)Buffer::Length(outbuf);
 
   size_t b = lame_get_id3v2_tag(gfp, buf, buf_size);
-  NanReturnValue(NanNew<Integer>(b));
+  NanReturnValue(NanNew<Integer>(static_cast<uint32_t>(b)));
 }
 
 
@@ -390,7 +390,7 @@ void InitLame(Handle<Object> target) {
 
   /* sizeof's */
 #define SIZEOF(value) \
-  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(sizeof(value)), \
+  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(static_cast<uint32_t>(sizeof(value))), \
       static_cast<PropertyAttribute>(ReadOnly|DontDelete))
   SIZEOF(short);
   SIZEOF(int);

--- a/src/node_mpg123.cc
+++ b/src/node_mpg123.cc
@@ -270,7 +270,7 @@ void node_mpg123_read_after (uv_work_t *req) {
 
   Handle<Value> argv[3];
   argv[0] = NanNew<Integer>(r->rtn);
-  argv[1] = NanNew<Integer>(r->done);
+  argv[1] = NanNew<Integer>(static_cast<uint32_t>(r->done));
   argv[2] = NanNew<Integer>(r->meta);
 
   TryCatch try_catch;


### PR DESCRIPTION
This fixes compilation with nan `> 1.5.0` and works with node `0.12.0`.

@TooTallNate After arriving at the same conclusions as you did I found rvagg/nan#279. The only difference is that I used `uint32_t` instead of `int32_t`. I believe that it's correct to use `uint32_t` since `size_t` is unsigned (and `ssize_t` is signed).