### PR TITLE
use uint32_t instead of size_t for nan

### DIFF
--- a/src/node_lame.cc
+++ b/src/node_lame.cc
@@ -259,7 +259,7 @@ NAN_METHOD(node_lame_get_id3v1_tag) {
   unsigned char *buf = (unsigned char *)Buffer::Data(outbuf);
   size_t buf_size = (size_t)Buffer::Length(outbuf);
 
-  size_t b = lame_get_id3v1_tag(gfp, buf, buf_size);
+  uint32_t b = lame_get_id3v1_tag(gfp, buf, buf_size);
   NanReturnValue(NanNew<Integer>(b));
 }
 
@@ -276,7 +276,7 @@ NAN_METHOD(node_lame_get_id3v2_tag) {
   unsigned char *buf = (unsigned char *)Buffer::Data(outbuf);
   size_t buf_size = (size_t)Buffer::Length(outbuf);
 
-  size_t b = lame_get_id3v2_tag(gfp, buf, buf_size);
+  uint32_t b = lame_get_id3v2_tag(gfp, buf, buf_size);
   NanReturnValue(NanNew<Integer>(b));
 }
 
@@ -390,7 +390,7 @@ void InitLame(Handle<Object> target) {
 
   /* sizeof's */
 #define SIZEOF(value) \
-  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(sizeof(value)), \
+  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(uint32_t (sizeof(value))), \
       static_cast<PropertyAttribute>(ReadOnly|DontDelete))
   SIZEOF(short);
   SIZEOF(int);

--- a/src/node_mpg123.cc
+++ b/src/node_mpg123.cc
@@ -270,7 +270,7 @@ void node_mpg123_read_after (uv_work_t *req) {
 
   Handle<Value> argv[3];
   argv[0] = NanNew<Integer>(r->rtn);
-  argv[1] = NanNew<Integer>(r->done);
+  argv[1] = NanNew<Integer>(uint32_t (r->done));
   argv[2] = NanNew<Integer>(r->meta);
 
   TryCatch try_catch;


### PR DESCRIPTION
On Mac OS X (10.10.2) (LLVM 6.0), I get this error at compilation:

```
../node_modules/nan/nan_new.h:209:10: error: call to 'New' is ambiguous
  return NanIntern::Factory<T>::New(arg0);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
../src/node_lame.cc:395:3: note: in instantiation of function template specialization 'NanNew<v8::Integer, unsigned long>' requested
      here
  SIZEOF(short);
  ^
../src/node_lame.cc:393:54: note: expanded from macro 'SIZEOF'
  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(sizeof(value)), \
                                                     ^
../node_modules/nan/nan_new.h:109:26: note: candidate function
  static inline return_t New(int32_t value);
                         ^
../node_modules/nan/nan_new.h:110:26: note: candidate function
  static inline return_t New(uint32_t value);
```

It's caused by passing a `size_t`to `NanNew<Integer>`. If fixed this casting all `size_t` passed to `NanNew<Integer>` to `uint32_t`.