### PR TITLE
Fixes to compile under Win64 with VS2013

### DIFF
--- a/src/node_lame.cc
+++ b/src/node_lame.cc
@@ -260,7 +260,7 @@ NAN_METHOD(node_lame_get_id3v1_tag) {
   size_t buf_size = (size_t)Buffer::Length(outbuf);
 
   size_t b = lame_get_id3v1_tag(gfp, buf, buf_size);
-  NanReturnValue(NanNew<Integer>(b));
+  NanReturnValue(NanNew<Integer>(static_cast<int32_t>(b)));
 }
 
 
@@ -277,7 +277,7 @@ NAN_METHOD(node_lame_get_id3v2_tag) {
   size_t buf_size = (size_t)Buffer::Length(outbuf);
 
   size_t b = lame_get_id3v2_tag(gfp, buf, buf_size);
-  NanReturnValue(NanNew<Integer>(b));
+  NanReturnValue(NanNew<Integer>(static_cast<int32_t>(b)));
 }
 
 
@@ -390,7 +390,7 @@ void InitLame(Handle<Object> target) {
 
   /* sizeof's */
 #define SIZEOF(value) \
-  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(sizeof(value)), \
+  target->ForceSet(NanNew<String>("sizeof_" #value), NanNew<Integer>(static_cast<int32_t>(sizeof(value))), \
       static_cast<PropertyAttribute>(ReadOnly|DontDelete))
   SIZEOF(short);
   SIZEOF(int);

--- a/src/node_mpg123.cc
+++ b/src/node_mpg123.cc
@@ -270,7 +270,7 @@ void node_mpg123_read_after (uv_work_t *req) {
 
   Handle<Value> argv[3];
   argv[0] = NanNew<Integer>(r->rtn);
-  argv[1] = NanNew<Integer>(r->done);
+  argv[1] = NanNew<Integer>(static_cast<int32_t>(r->done));
   argv[2] = NanNew<Integer>(r->meta);
 
   TryCatch try_catch;


### PR DESCRIPTION
All this does is add a bunch of casts to resolve templates that otherwise fail to resolve when compiling with VS2013 under Windows when running in a 64-bit environment.