### PR TITLE
Fix encoder memory leak

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -221,6 +221,10 @@ Encoder.prototype._flush = function (done) {
 
   function cb (bytesWritten) {
     debug('after lame_encode_flush_nogap() (rtn: %d)', bytesWritten);
+
+    binding.lame_close(self.gfp);
+    self.gfp = null;
+
     if (bytesWritten < 0) {
       var err = new Error(ERRORS[bytesWritten]);
       err.code = bytesWritten;


### PR DESCRIPTION
**Before** (lost for each encoded file, extract):

```bash
0x7fb6c5ca148a  1600       1      1        /tmp/node_modules/lame...  InitVbrTag                                        +0x14a
0x7fb6c5c8151c  2772       1      1        /tmp/node_modules/lame...  lame_init_params                                  +0x23dc
0x7fb6c5c83fc8  4492       2      2        /tmp/node_modules/lame...
0x7fb6c5c88228  6528       1      1        /tmp/node_modules/lame...  psymodel_init                                     +0x88
0x7fb6c5c7e5bf  65536      1      1        /tmp/node_modules/lame...  lame_encode_buffer_interleaved                    +0x9f
0x7fb6c5c7e5db  65536      1      1        /tmp/node_modules/lame...  lame_encode_buffer_interleaved                    +0xbb
0xc1aa3a        74224      1      1        node
0x7fb6c5c81d40  88584      1      1        /tmp/node_modules/lame...  lame_init                                         +0x50
0x7fb6c5c8154f  134840     1      1        /tmp/node_modules/lame...  lame_init_params                                  +0x240f
0x7fb6c5ca8064  147456     1      1        /tmp/node_modules/lame...  init_bit_stream_w                                 +0x34
--------------  ---------  -----  -------  -------------------------  ------------------------------------------------  -------
Totals          604440     35     38883
```

**After**: all buffers allocated by lame well freed :smiley_cat: 