### PR TITLE
Updated nan to v2.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bindings": "~1.2.0",
     "debug": "2",
     "readable-stream": "1.0",
-    "nan": "~2.0.8"
+    "nan": "~2.2.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
I was encountering an error when building node-lame on my Raspberry Pi 2 using node v5.5.0:

error: ‘v8::HandleScope::HandleScope()’ is protected

After some digging, it seemed like an update to nan would resolve the issue. Updated to v2.2.0. Tests pass. Node-lame now builds successfully on the Pi with node v5.5.0.