### PR TITLE
Bump dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ node_js:
   - "iojs-v1"
   - "iojs-v2"
   - "iojs-v3"
+  - "4"
+  - "6"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   },
   "main": "./index.js",
   "dependencies": {
-    "bindings": "~1.2.0",
-    "debug": "2",
-    "readable-stream": "1.0",
-    "nan": "~2.3.5"
+    "bindings": "^1.2.1",
+    "debug": "^2.2.0",
+    "readable-stream": "^1.0.34",
+    "nan": "^2.3.5"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "^2.4.5"
   },
   "scripts": {
     "test": "mocha --reporter spec"


### PR DESCRIPTION
Fixes compatibility with Node.js 6.x by using a newer version of nan.

Fixes #62

@TooTallNate I'd be happy to jump on as a maintainer if you need more hands on this 👍  also, check out [line-in](https://npmjs.com/line-in) if you have time, it was inspired by this library 🙌 