### PR TITLE
Update package.json to newer version of NAN

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bindings": "~1.2.0",
     "debug": "2",
     "readable-stream": "1.0",
-    "nan": "~2.0.8"
+    "nan": "~2.3.5"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
without the latest version of NAN node-lame will not compile with node 6.